### PR TITLE
Improvements to product manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,30 @@ When a single product is requested, all fields of that product are returned and 
 *	GBP
 
 The latest exchange rates are retrieved from the public API https://currencylayer.com/. Tests are optional but we would like to hear from you how would you design such tests at the interview.
+
+
+## Changes
+1. API's to get product by id, one to handle requests with optional currency and another to handle requests with currency.
+2. Logic to increment product view count during get product call.
+3. Logic to fetch currency exchange rates and convert the product price to the input currency during get product call.
+4. To avoid chatty calls to external https://currencylayer.com/ for every get product request, the following improvements done
+    1. A `quote` postgres table is created which contains the latest exchange rates for the supported currency.
+    2. The `FxService` contains a scheduler which fetches the forex exchange rates at an interval and updates the `quote` table
+    3. The `FxService` uses the `quote` tables to fetch the currency exchange rate.
+    4. By doing so, the calls to convert the product price to given currency doesn't hit https://currencylayer.com/ for every request
+5. Utils:
+    1. Supported currencies as enums
+    2. String to Enum converter helper
+6. E2E tests targeting the product rest api's
+
+#### Tests
+<img width="414" alt="prodman_–_ProductEnd2EndTest_java__prodman_test_" src="https://user-images.githubusercontent.com/3944743/141608519-884c860f-367b-4fa3-96de-6dc5e773e528.png">
+
+
+## Improvements
+1. Tests for rest, service and repository packages
+2. Decouple `ProductService` and `FxService`. Apply single responsibility principle. Converting product price to given currency should be outside of `ProductService`.
+3. Tune the scheduler logic to fetch/update the forex exchange rates as needed.
+4. Error handling, logging, metrics and observability.
+5. Improve development experience by spinning up local docker container with postgres server, and connecting the application to it.
+    1. Skip calling https://currencylayer.com/ during development by using a pre-loaded `quote` table.

--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,15 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-validation')
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
     implementation('org.springdoc:springdoc-openapi-ui:1.5.2')
+    implementation('com.google.guava:guava:30.1.1-jre')
     runtimeOnly('org.postgresql:postgresql')
     compileOnly('org.projectlombok:lombok')
     annotationProcessor('org.projectlombok:lombok')
     testCompileOnly('org.projectlombok:lombok')
     testAnnotationProcessor('org.projectlombok:lombok')
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation ('junit:junit:4.13')
+    testImplementation ('org.assertj:assertj-core:3.17.2')
 }
 
 test {

--- a/src/main/java/com/galvanize/prodman/ProdmanApplication.java
+++ b/src/main/java/com/galvanize/prodman/ProdmanApplication.java
@@ -3,9 +3,11 @@ package com.galvanize.prodman;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
 @SpringBootApplication
+@EnableScheduling
 public class ProdmanApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/galvanize/prodman/domain/Quote.java
+++ b/src/main/java/com/galvanize/prodman/domain/Quote.java
@@ -1,0 +1,26 @@
+package com.galvanize.prodman.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.util.Date;
+
+
+@Entity
+@Getter
+@Setter
+public class Quote {
+    @Id
+    @Column(nullable = false, length = 50)
+    private String currency;
+
+    @Column(nullable = false, precision = 10, scale = 6)
+    private Double value;
+
+    @UpdateTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column
+    private Date updatedAt;
+}

--- a/src/main/java/com/galvanize/prodman/model/Currency.java
+++ b/src/main/java/com/galvanize/prodman/model/Currency.java
@@ -1,0 +1,8 @@
+package com.galvanize.prodman.model;
+
+/**
+ * @author Krishna Sadasivam
+ */
+public enum Currency {
+    USD, CAD, EUR, GBP
+}

--- a/src/main/java/com/galvanize/prodman/model/ProductDTO.java
+++ b/src/main/java/com/galvanize/prodman/model/ProductDTO.java
@@ -28,4 +28,9 @@ public class ProductDTO {
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     @Schema(type = "string", example = "1.00")
     private Double price;
+
+    @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @Schema(type = "string", example = "1")
+    private Integer views;
 }

--- a/src/main/java/com/galvanize/prodman/repository/FxRepository.java
+++ b/src/main/java/com/galvanize/prodman/repository/FxRepository.java
@@ -1,0 +1,16 @@
+package com.galvanize.prodman.repository;
+
+import java.util.Map;
+
+/**
+ * @author Krishna Sadasivam
+ */
+public interface FxRepository {
+
+    /**
+     * Get currency quotes from forex repository.
+     *
+     * @return map of currency to its value.
+     */
+    Map<String, Double> getQuotes();
+}

--- a/src/main/java/com/galvanize/prodman/repository/FxRepositoryImpl.java
+++ b/src/main/java/com/galvanize/prodman/repository/FxRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.galvanize.prodman.repository;
+
+import com.galvanize.prodman.model.Currency;
+import com.galvanize.prodman.model.FxResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Krishna Sadasivam
+ */
+@Service
+public class FxRepositoryImpl implements FxRepository {
+    private static final String SUPPORTED_CURRENCIES = String.format("%s,%s,%s,%s",
+            Currency.USD, Currency.CAD, Currency.EUR, Currency.GBP);
+    private final String fxApiUrl;
+    private final String fxApiKey;
+    private final RestTemplate restTemplate;
+
+    public FxRepositoryImpl(final RestTemplateBuilder restTemplateBuilder,
+                            @Value("${fx.api.url}") String fxApiUrl,
+                            @Value("${fx.api.key}") String fxApiKey) {
+        this.fxApiUrl = fxApiUrl;
+        this.fxApiKey = fxApiKey;
+        this.restTemplate = restTemplateBuilder.build();
+    }
+
+    @Override
+    public Map<String, Double> getQuotes() {
+        String endPoint = String.format("%s?access_key=%s&currencies=%s&format=1", fxApiUrl, fxApiKey, SUPPORTED_CURRENCIES);
+        FxResponse fxResponse = restTemplate.getForObject(endPoint, FxResponse.class);
+        return Objects.requireNonNull(fxResponse).getQuotes();
+    }
+}

--- a/src/main/java/com/galvanize/prodman/repository/ProductRepository.java
+++ b/src/main/java/com/galvanize/prodman/repository/ProductRepository.java
@@ -2,7 +2,16 @@ package com.galvanize.prodman.repository;
 
 import com.galvanize.prodman.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import javax.transaction.Transactional;
 
 
 public interface ProductRepository extends JpaRepository<Product, Integer> {
+    @Modifying
+    @Transactional
+    @Query("update Product p set p.views = p.views + :count where p.id = :id")
+    void incrementViewsByCount(@Param(value = "id") Integer id, @Param(value = "count") Integer count);
 }

--- a/src/main/java/com/galvanize/prodman/repository/QuoteRepository.java
+++ b/src/main/java/com/galvanize/prodman/repository/QuoteRepository.java
@@ -1,0 +1,10 @@
+package com.galvanize.prodman.repository;
+
+import com.galvanize.prodman.domain.Quote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @author Krishna Sadasivam
+ */
+public interface QuoteRepository extends JpaRepository<Quote, String> {
+}

--- a/src/main/java/com/galvanize/prodman/rest/ProductController.java
+++ b/src/main/java/com/galvanize/prodman/rest/ProductController.java
@@ -1,9 +1,15 @@
 package com.galvanize.prodman.rest;
 
+import com.galvanize.prodman.model.Currency;
+import com.galvanize.prodman.model.ProductDTO;
 import com.galvanize.prodman.service.ProductService;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.galvanize.prodman.util.EnumMapper.getEnumFromString;
 
 
 @RestController
@@ -12,5 +18,22 @@ public class ProductController {
 
     private final ProductService productService;
 
-    public ProductController(final ProductService productService) { this.productService = productService; }
+    public ProductController(final ProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping(value = "product/{productId}/{currency}")
+    public ProductDTO get(@PathVariable String productId, @PathVariable String currency) {
+        Currency c = getEnumFromString(Currency.class, currency).orElse(Currency.USD);
+        Integer id = Integer.valueOf(productId);
+
+        ProductDTO productDTO = this.productService.get(id, c);
+        this.productService.incrementViewCountByOne(id);
+        return productDTO;
+    }
+
+    @GetMapping(value = "product/{productId}")
+    public ProductDTO getByDefaultCurrency(@PathVariable String productId) {
+        return get(productId, Currency.USD.name());
+    }
 }

--- a/src/main/java/com/galvanize/prodman/service/FxService.java
+++ b/src/main/java/com/galvanize/prodman/service/FxService.java
@@ -1,28 +1,19 @@
 package com.galvanize.prodman.service;
 
-import com.galvanize.prodman.model.FxResponse;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import com.galvanize.prodman.domain.Quote;
 
-@Service
-public class FxService {
+import java.util.Optional;
 
-  private static final String SUPPORTED_CURRENCIES = "USD,CAD,EUR,GBP";
+/**
+ * @author Krishna Sadasivam
+ */
+public interface FxService {
 
-  @Value("${fx.api.url}")
-  private String fxApiUrl;
-
-  @Value("${fx.api.key}")
-  private String fxApiKey;
-
-  private final RestTemplate restTemplate;
-
-  public FxService(final RestTemplateBuilder restTemplateBuilder) { this.restTemplate = restTemplateBuilder.build(); }
-
-  public FxResponse getQuotes() {
-    String endPoint = String.format("%s?access_key=%s&currencies=%s&format=1", fxApiUrl, fxApiKey, SUPPORTED_CURRENCIES);
-    return restTemplate.getForObject(endPoint, FxResponse.class);
-  }
+  /**
+   * Gets the forex quote for the currency.
+   *
+   * @param currency the currency for which a forex quote is returned.
+   * @return the forex quote.
+   */
+  Optional<Quote> get(Currency currency);
 }

--- a/src/main/java/com/galvanize/prodman/service/FxService.java
+++ b/src/main/java/com/galvanize/prodman/service/FxService.java
@@ -1,6 +1,7 @@
 package com.galvanize.prodman.service;
 
 import com.galvanize.prodman.domain.Quote;
+import com.galvanize.prodman.model.Currency;
 
 import java.util.Optional;
 

--- a/src/main/java/com/galvanize/prodman/service/FxServiceImpl.java
+++ b/src/main/java/com/galvanize/prodman/service/FxServiceImpl.java
@@ -1,0 +1,48 @@
+package com.galvanize.prodman.service;
+
+import com.galvanize.prodman.domain.Quote;
+import com.galvanize.prodman.repository.FxRepository;
+import com.galvanize.prodman.repository.QuoteRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class FxServiceImpl implements FxService {
+
+    private static final Currency DEFAULT_CURRENCY = Currency.USD;
+    private final QuoteRepository quoteRepository;
+    private final FxRepository fxRepository;
+
+    public FxServiceImpl(final FxRepository fxRepository,
+                         final QuoteRepository quoteRepository) {
+        this.fxRepository = fxRepository;
+        this.quoteRepository = quoteRepository;
+        updateQuotes();
+    }
+
+    @Scheduled(fixedRate = 60 * 60 * 1000 /* one hour */)
+    public void updateQuotes() {
+        Set<Quote> quotes = this.fxRepository.getQuotes()
+                .entrySet()
+                .stream()
+                .map(pair -> {
+                    Quote q = new Quote();
+                    q.setCurrency(pair.getKey());
+                    q.setValue(pair.getValue());
+                    return q;
+                })
+                .collect(Collectors.toSet());
+
+        this.quoteRepository.saveAllAndFlush(quotes);
+    }
+
+    @Override
+    public Optional<Quote> get(Currency currency) {
+        String id = DEFAULT_CURRENCY.name() + currency.name();
+        return this.quoteRepository.findById(id);
+    }
+}

--- a/src/main/java/com/galvanize/prodman/service/FxServiceImpl.java
+++ b/src/main/java/com/galvanize/prodman/service/FxServiceImpl.java
@@ -1,6 +1,7 @@
 package com.galvanize.prodman.service;
 
 import com.galvanize.prodman.domain.Quote;
+import com.galvanize.prodman.model.Currency;
 import com.galvanize.prodman.repository.FxRepository;
 import com.galvanize.prodman.repository.QuoteRepository;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/galvanize/prodman/service/ProductService.java
+++ b/src/main/java/com/galvanize/prodman/service/ProductService.java
@@ -1,39 +1,40 @@
 package com.galvanize.prodman.service;
 
-import com.galvanize.prodman.domain.Product;
+import com.galvanize.prodman.model.Currency;
 import com.galvanize.prodman.model.ProductDTO;
-import com.galvanize.prodman.repository.ProductRepository;
-import org.springframework.stereotype.Service;
 
+/**
+ * @author Krishna Sadasivam
+ */
+public interface ProductService {
+    /**
+     * Creates a product
+     *
+     * @param productDTO The product.
+     * @return the product id.
+     */
+    Integer create(final ProductDTO productDTO);
 
-@Service
-public class ProductService {
+    /**
+     * Gets a product and augments the price of the product to reflect the currency.
+     *
+     * @param id       the product id.
+     * @param currency the currency to which the price of the product is converted.
+     * @return the product.
+     */
+    ProductDTO get(final Integer id, final Currency currency);
 
-    private final ProductRepository productRepository;
-    private final FxService fxService;
+    /**
+     * Increments the product view count by one.
+     *
+     * @param id the product id.
+     */
+    void incrementViewCountByOne(final Integer id);
 
-    public ProductService(final ProductRepository productRepository, final FxService fxService) {
-        this.productRepository = productRepository;
-        this.fxService = fxService;
-    }
-
-    public Integer create(final ProductDTO productDTO) {
-        final Product product = new Product();
-        mapToEntity(productDTO, product);
-        return productRepository.save(product).getId();
-    }
-
-    public void delete(final Integer id) {
-        productRepository.deleteById(id);
-    }
-
-    private Product mapToEntity(final ProductDTO productDTO, final Product product) {
-        product.setName(productDTO.getName());
-        product.setDescription(productDTO.getDescription());
-        product.setPrice(productDTO.getPrice());
-        product.setViews(0);
-        product.setDeleted(false);
-        return product;
-    }
-
+    /**
+     * Deleted the product by id.
+     *
+     * @param id the product id.
+     */
+    void delete(final Integer id);
 }

--- a/src/main/java/com/galvanize/prodman/service/ProductServiceImpl.java
+++ b/src/main/java/com/galvanize/prodman/service/ProductServiceImpl.java
@@ -1,0 +1,64 @@
+package com.galvanize.prodman.service;
+
+import com.galvanize.prodman.domain.Product;
+import com.galvanize.prodman.domain.Quote;
+import com.galvanize.prodman.model.ProductDTO;
+import com.galvanize.prodman.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ProductServiceImpl implements ProductService {
+
+    private final ProductRepository productRepository;
+    private final FxService fxService;
+
+    public ProductServiceImpl(final ProductRepository productRepository, final FxService fxService) {
+        this.productRepository = productRepository;
+        this.fxService = fxService;
+    }
+
+    @Override
+    public Integer create(final ProductDTO productDTO) {
+        final Product product = new Product();
+        mapToEntity(productDTO, product);
+        return productRepository.saveAndFlush(product).getId();
+    }
+
+    @Override
+    public ProductDTO get(final Integer id, final Currency currency) {
+        Optional<Product> product = productRepository.findById(id);
+        Optional<Quote> quote = this.fxService.get(currency);
+        return mapToDto(product.get(), quote.get());
+    }
+
+    @Override
+    public void incrementViewCountByOne(Integer id) {
+        this.productRepository.incrementViewsByCount(id, 1);
+    }
+
+    @Override
+    public void delete(final Integer id) {
+        productRepository.deleteById(id);
+    }
+
+    private Product mapToEntity(final ProductDTO productDTO, final Product product) {
+        product.setName(productDTO.getName());
+        product.setDescription(productDTO.getDescription());
+        product.setPrice(productDTO.getPrice());
+        product.setViews(0);
+        product.setDeleted(false);
+        return product;
+    }
+
+    private ProductDTO mapToDto(final Product product, final Quote quote) {
+        ProductDTO productDTO = new ProductDTO();
+        productDTO.setId(product.getId());
+        productDTO.setName(product.getName());
+        productDTO.setDescription(product.getDescription());
+        productDTO.setPrice(product.getPrice() * quote.getValue());
+        productDTO.setViews(product.getViews());
+        return productDTO;
+    }
+}

--- a/src/main/java/com/galvanize/prodman/service/ProductServiceImpl.java
+++ b/src/main/java/com/galvanize/prodman/service/ProductServiceImpl.java
@@ -2,6 +2,7 @@ package com.galvanize.prodman.service;
 
 import com.galvanize.prodman.domain.Product;
 import com.galvanize.prodman.domain.Quote;
+import com.galvanize.prodman.model.Currency;
 import com.galvanize.prodman.model.ProductDTO;
 import com.galvanize.prodman.repository.ProductRepository;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/galvanize/prodman/util/EnumMapper.java
+++ b/src/main/java/com/galvanize/prodman/util/EnumMapper.java
@@ -1,0 +1,22 @@
+package com.galvanize.prodman.util;
+
+import com.google.common.base.Strings;
+
+import java.util.Optional;
+
+/**
+ * @author Krishna Sadasivam
+ */
+public final class EnumMapper {
+
+    public static <T extends Enum<T>> Optional<T> getEnumFromString(Class<T> c, String s) {
+        if (!Strings.isNullOrEmpty(s)) {
+            try {
+                return Optional.of(Enum.valueOf(c, s.trim().toUpperCase()));
+            } catch (IllegalArgumentException e) {
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/test/java/com/galvanize/prodman/rest/ProductEnd2EndTest.java
+++ b/src/test/java/com/galvanize/prodman/rest/ProductEnd2EndTest.java
@@ -1,0 +1,123 @@
+package com.galvanize.prodman.rest;
+
+import com.galvanize.prodman.model.ProductDTO;
+import com.galvanize.prodman.repository.QuoteRepository;
+import com.galvanize.prodman.service.ProductServiceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.jdbc.JdbcTestUtils;
+
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Krishna Sadasivam
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ProductEnd2EndTest {
+    @Autowired
+    private QuoteRepository quoteRepository;
+    @LocalServerPort
+    private int port;
+    @Autowired
+    private TestRestTemplate restTemplate;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private ProductServiceImpl productService;
+
+    @AfterEach
+    void tearDown() {
+        JdbcTestUtils.deleteFromTables(jdbcTemplate, "product");
+    }
+
+    @Test
+    public void getProductWithDefaultCurrency() {
+        ProductDTO expected = createNewProduct();
+        ProductDTO actual = this.restTemplate.getForObject("http://localhost:" + port + "/api/product/" + expected.getId(),
+                ProductDTO.class);
+
+        assertThat(actual.getId()).isEqualTo(expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertThat(actual.getPrice()).isEqualTo(expected.getPrice());
+        assertThat(actual.getViews()).isEqualTo(0);
+    }
+
+    @Test
+    public void getProductWithCADCurrency() {
+        ProductDTO expected = createNewProduct();
+        ProductDTO actual = this.restTemplate.getForObject("http://localhost:" + port + "/api/product/" + expected.getId() + "/CAD",
+                ProductDTO.class);
+
+        assertThat(actual.getId()).isEqualTo(expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertThat(actual.getPrice()).isEqualTo(expected.getPrice() * quoteRepository.findById("USDCAD").get().getValue());
+        assertThat(actual.getViews()).isEqualTo(0);
+    }
+
+    @Test
+    public void getProductWithEURCurrency() {
+        ProductDTO expected = createNewProduct();
+        ProductDTO actual = this.restTemplate.getForObject("http://localhost:" + port + "/api/product/" + expected.getId() + "/EUR",
+                ProductDTO.class);
+
+        assertThat(actual.getId()).isEqualTo(expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertThat(actual.getPrice()).isEqualTo(expected.getPrice() * quoteRepository.findById("USDEUR").get().getValue());
+        assertThat(actual.getViews()).isEqualTo(0);
+    }
+
+    @Test
+    public void getProductWithGBPCurrency() {
+        ProductDTO expected = createNewProduct();
+        ProductDTO actual = this.restTemplate.getForObject("http://localhost:" + port + "/api/product/" + expected.getId() + "/GBP",
+                ProductDTO.class);
+
+        assertThat(actual.getId()).isEqualTo(expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertThat(actual.getPrice()).isEqualTo(expected.getPrice() * quoteRepository.findById("USDGBP").get().getValue());
+        assertThat(actual.getViews()).isEqualTo(0);
+    }
+
+    @Test
+    public void concurrentGetProducts() {
+        ProductDTO expected = createNewProduct();
+        int numberOfViews = 10;
+
+        IntStream.range(0, numberOfViews).parallel().forEach(i ->
+                this.restTemplate.getForObject("http://localhost:" + port + "/api/product/" + expected.getId() + "/USD",
+                        ProductDTO.class));
+
+        ProductDTO actual = this.restTemplate.getForObject("http://localhost:" + port + "/api/product/" + expected.getId() + "/USD",
+                ProductDTO.class);
+
+        assertThat(actual.getViews()).isEqualTo(numberOfViews);
+        assertThat(actual.getId()).isEqualTo(expected.getId());
+        assertThat(actual.getName()).isEqualTo(expected.getName());
+        assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
+        assertThat(actual.getPrice()).isEqualTo(expected.getPrice());
+    }
+
+
+    private ProductDTO createNewProduct() {
+        ProductDTO p = new ProductDTO();
+        p.setName(UUID.randomUUID().toString());
+        p.setDescription(UUID.randomUUID().toString());
+        p.setPrice(10.50);
+
+        Integer productId = this.productService.create(p);
+        p.setId(productId);
+        return p;
+    }
+}


### PR DESCRIPTION

## Changes
1. API's to get a product by id, one to handle requests with optional currency and another to handle requests with currency.
2. Logic to increment product view count during get product call.
3. Logic to fetch currency exchange rates and convert the product price to the input currency during get product call.
4. To avoid chatty calls to external https://currencylayer.com/ for every get product request, the following improvements done
    1. A `quote` Postgres table is created which contains the latest exchange rates for the supported currency.
    2. The `FxService` contains a scheduler that fetches the forex exchange rates at an interval and updates the `quote` table
    3. The `FxService` uses the `quote` tables to fetch the currency exchange rate.
    4. By doing so, the calls to convert the product price to a given currency doesn't hit https://currencylayer.com/ for every request
5. Utils:
    1. Supported currencies as enums
    2. String to Enum converter helper
6. E2E tests targeting the product rest api's

#### Tests
<img width="414" alt="prodman_–_ProductEnd2EndTest_java__prodman_test_" src="https://user-images.githubusercontent.com/3944743/141608519-884c860f-367b-4fa3-96de-6dc5e773e528.png">


## Improvements
1. Tests for rest, service, and repository packages
2. Decouple `ProductService` and `FxService`. Apply single responsibility principle. Converting product price to given currency should be outside of `ProductService`.
3. Tune the scheduler logic to fetch/update the forex exchange rates as needed.
4. Error handling, logging, metrics, and observability.
5. Improve development experience by spinning up a local docker container with postgres server, and connecting the application to it.
    1. Skip calling https://currencylayer.com/ during development by using a pre-loaded `quote` table.